### PR TITLE
feat: Supports the management of zookeepers including start, stop, status and reset

### DIFF
--- a/src/docker/Dockerfile
+++ b/src/docker/Dockerfile
@@ -1,0 +1,33 @@
+#   Licensed to the Apache Software Foundation (ASF) under one or more
+#   contributor license agreements.  See the NOTICE file distributed with
+#   this work for additional information regarding copyright ownership.
+#   The ASF licenses this file to You under the Apache License, Version 2.0
+#   (the "License"); you may not use this file except in compliance with
+#   the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+ARG JAVA_VER=8
+FROM openjdk:$JAVA_VER
+
+ARG DEBIAN_MIRROR
+RUN if [ -n "$DEBIAN_MIRROR" ]; then \
+  sed -i "s@http://deb.debian.org@${DEBIAN_MIRROR}@g" /etc/apt/sources.list && \
+  sed -i "s@http://security.debian.org@${DEBIAN_MIRROR}@g" /etc/apt/sources.list && \
+  cat /etc/apt/sources.list ; fi
+
+RUN apt-get update && \
+  apt-get install -y telnet && \
+  rm -rf /var/lib/apt/lists/*
+
+VOLUME /usr/local/zookeeper
+
+WORKDIR /usr/local/zookeeper/
+#ENTRYPOINT exec build zookeeper instances
+ENTRYPOINT ["bash", "-x", "./init.sh"]

--- a/src/docker/init.sh
+++ b/src/docker/init.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+DIR=/usr/local/zookeeper/
+if [ ! -d $DIR ];then
+  mkdir -p $DIR
+fi
+
+cd $DIR
+
+LOG_DIR=/usr/local/zookeeper/logs
+if [ ! -d $LOG_DIR ];then
+  mkdir -p $LOG_DIR
+  mkdir -p $LOG_DIR/2181
+  mkdir -p $LOG_DIR/2182
+fi
+
+ZOOKEEPER_DIR_2181=/usr/local/zookeeper/2181
+if [ ! -d $ZOOKEEPER_DIR_2181 ];then
+  mkdir -p $ZOOKEEPER_DIR_2181
+fi
+
+ZOOKEEPER_DIR_2182=/usr/local/zookeeper/2182
+if [ ! -d $ZOOKEEPER_DIR_2182 ];then
+  mkdir -p $ZOOKEEPER_DIR_2182
+fi
+
+# download zookeeper
+wget -O apache-zookeeper.tar.gz -c -N --show-progress  https://archive.apache.org/dist/zookeeper/zookeeper-3.6.0/apache-zookeeper-3.6.0-bin.tar.gz
+
+# install with 2181
+tar -zxvf apache-zookeeper.tar.gz -C $ZOOKEEPER_DIR_2181
+mv $ZOOKEEPER_DIR_2181/apache-zookeeper-3.6.0-bin $ZOOKEEPER_DIR_2181/apache-zookeeper-3.6.0-2181
+cp $ZOOKEEPER_DIR_2181/apache-zookeeper-3.6.0-2181/conf/zoo_sample.cfg $ZOOKEEPER_DIR_2181/apache-zookeeper-3.6.0-2181/conf/zoo.cfg
+sed -i '' "s#^dataDir=.*#dataDir=$LOG_DIR/2181#g" $ZOOKEEPER_DIR_2181/apache-zookeeper-3.6.0-2181/conf/zoo.cfg
+echo "admin.serverPort=8081" >> $ZOOKEEPER_DIR_2181/apache-zookeeper-3.6.0-2181/conf/zoo.cfg
+
+# install with 2182
+tar -zxvf apache-zookeeper.tar.gz -C $ZOOKEEPER_DIR_2182
+mv $ZOOKEEPER_DIR_2182/apache-zookeeper-3.6.0-bin $ZOOKEEPER_DIR_2182/apache-zookeeper-3.6.0-2182
+cp $ZOOKEEPER_DIR_2182/apache-zookeeper-3.6.0-2182/conf/zoo_sample.cfg $ZOOKEEPER_DIR_2182/apache-zookeeper-3.6.0-2182/conf/zoo.cfg
+sed -i '' "s#^dataDir=.*#dataDir=$LOG_DIR/2182#g" $ZOOKEEPER_DIR_2182/apache-zookeeper-3.6.0-2182/conf/zoo.cfg
+sed -i '' "s#^clientPort=.*#clientPort=2182#g" $ZOOKEEPER_DIR_2182/apache-zookeeper-3.6.0-2182/conf/zoo.cfg
+echo "admin.serverPort=8082" >> $ZOOKEEPER_DIR_2182/apache-zookeeper-3.6.0-2182/conf/zoo.cfg

--- a/src/docker/mock-zookeeper.sh
+++ b/src/docker/mock-zookeeper.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+ZOOKEEPER_HOME_2181=/usr/local/zookeeper/2181/apache-zookeeper-3.6.0-2181
+ZOOKEEPER_HOME_2182=/usr/local/zookeeper/2182/apache-zookeeper-3.6.0-2182
+ZOOKEEPER_SERVER_2181=$ZOOKEEPER_HOME_2181/bin/zkServer.sh
+ZOOKEEPER_SERVER_2182=$ZOOKEEPER_HOME_2182/bin/zkServer.sh
+ZOOKEEPER_CLIENT_2181=$ZOOKEEPER_HOME_2181/bin/zkCli.sh
+ZOOKEEPER_CLIENT_2182=$ZOOKEEPER_HOME_2182/bin/zkCli.sh
+
+case $1 in 
+start)
+    echo "start zookeeper"
+    ./init.sh
+    $ZOOKEEPER_SERVER_2181 start
+    $ZOOKEEPER_SERVER_2182 start
+    ;;
+stop)
+    echo "stop zookeeper"
+    if [ ! -f "$ZOOKEEPER_SERVER_2181" ]; then
+        echo "ERROR: please start zookeeper before"
+        return 1
+    fi
+    $ZOOKEEPER_SERVER_2181 stop
+    if [ ! -f "$ZOOKEEPER_SERVER_2182" ]; then
+        echo "ERROR: please start zookeeper before"
+        return 1
+    fi
+    $ZOOKEEPER_SERVER_2182 stop
+    ;;
+status)
+    echo "zookeeper info"
+    if [ ! -f "$ZOOKEEPER_SERVER_2181" ]; then
+        echo "ERROR: please start zookeeper before"
+        return 1
+    fi
+    $ZOOKEEPER_SERVER_2181 status
+    if [ ! -f "$ZOOKEEPER_SERVER_2182" ]; then
+        echo "ERROR: please start zookeeper before"
+        return 1
+    fi
+    $ZOOKEEPER_SERVER_2182 status
+    ;;
+reset)
+    echo "reset zookeeper"
+    if [ ! -f "$ZOOKEEPER_CLIENT_2181" ]; then
+        echo "ERROR: please start zookeeper before"
+        return 1
+    fi
+    $ZOOKEEPER_CLIENT_2181 -timeout 5000  -server 127.0.0.1:2181 deleteall /dubbo quit
+    if [ ! -f "$ZOOKEEPER_CLIENT_2182" ]; then
+        echo "ERROR: please start zookeeper before"
+        return 1
+    fi
+    $ZOOKEEPER_CLIENT_2182 -timeout 5000  -server 127.0.0.1:2182 deleteall /dubbo quit
+    ;;
+*)
+    echo "./mock-zookeeper.sh start|stop|status|reset"
+    exit 1
+    ;;
+esac
+exit 0


### PR DESCRIPTION
Manage two zookeeper instances with 2181 and 2182 ports, There are supported functions below
+ `start`: start two zookeeper instances
+ `stop`: stop the started zookeeper instances
+ `status`: see the status of zookeeper instances
+ `reset`: clear the node `dubbo` in zookeeper instances